### PR TITLE
chore: override @tootallnate/once to 2.0.1 (final low alert)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3839,13 +3839,13 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/aria-query": {

--- a/client/package.json
+++ b/client/package.json
@@ -64,6 +64,7 @@
     "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1",
-    "webpack-dev-server": "^5.2.1"
+    "webpack-dev-server": "^5.2.1",
+    "@tootallnate/once": "^2.0.1"
   }
 }


### PR DESCRIPTION
Final alert in this repo: @tootallnate/once < 2.0.1 (low, control-flow scoping) was pinned 1.x deep in react-scripts' http-proxy-agent chain -- npm override lands 2.0.1. Lockfile verified. Note: client build remains broken on main from the pre-existing Tailwind 4 PostCSS config issue (separate work item, documented in #264).